### PR TITLE
run_simulation! rename

### DIFF
--- a/Examples/Example_ActiveBrownian.jl
+++ b/Examples/Example_ActiveBrownian.jl
@@ -53,7 +53,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_ActiveBrownian_data.out")
+run_simulation!(simulation; save_as = "out/Example_ActiveBrownian_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_ActiveBrownianFunnels.jl
+++ b/Examples/Example_ActiveBrownianFunnels.jl
@@ -79,7 +79,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_ActiveBrownianFunnels_data.out")
+run_simulation!(simulation; save_as = "out/Example_ActiveBrownianFunnels_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_LennardJonesFluid.jl
+++ b/Examples/Example_LennardJonesFluid.jl
@@ -52,7 +52,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_LennardJonesFluid_data.out")
+run_simulation!(simulation; save_as = "out/Example_LennardJonesFluid_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_PolyDispersed.jl
+++ b/Examples/Example_PolyDispersed.jl
@@ -77,7 +77,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation, save_as = "out/Example_PolyDispersed_data.out")
+run_simulation!(simulation, save_as = "out/Example_PolyDispersed_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_RunAndTumble.jl
+++ b/Examples/Example_RunAndTumble.jl
@@ -53,7 +53,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_RunAndTumble_data.out")
+run_simulation!(simulation; save_as = "out/Example_RunAndTumble_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_RunAndTumbleFunnels.jl
+++ b/Examples/Example_RunAndTumbleFunnels.jl
@@ -79,7 +79,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_RunAndTumbleFunnels_data.out")
+run_simulation!(simulation; save_as = "out/Example_RunAndTumbleFunnels_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/Examples/Example_TwoTemperature.jl
+++ b/Examples/Example_TwoTemperature.jl
@@ -60,7 +60,7 @@ simulation.save_particles = pgroup_all
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Run simulation and save data
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-run_simulation(simulation; save_as = "out/Example_TwoTemperature_data.out")
+run_simulation!(simulation; save_as = "out/Example_TwoTemperature_data.out")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # OPTIONAL: Load simulation data and animate the simulation.  Individual frames

--- a/src/runsimulation.jl
+++ b/src/runsimulation.jl
@@ -1,4 +1,4 @@
-export run_simulation
+export run_simulation!
 export save_simulation
 export load_simulation
 
@@ -21,7 +21,7 @@ end
 Run the simulation.  `message_interval` (seconds) controls how often a time
 update is printed.  `save_as` is the file to which `simulation` is saved.
 """
-function run_simulation(simulation::Simulation; message_interval::Float64 = 10.0, save_as::String = "")
+function run_simulation!(simulation::Simulation; message_interval::Float64 = 10.0, save_as::String = "")
     println("")
     println("   +++++ SIMULATION STARTED +++++")
     println("")


### PR DESCRIPTION
rename `run_simulation` to `run_simulation!` to make naming consistent with other functions